### PR TITLE
[Feature] Implement setters in interfaces

### DIFF
--- a/api/src/main/java/com/bivashy/configurate/objectmapping/proxy/ProxyMethodFilter.java
+++ b/api/src/main/java/com/bivashy/configurate/objectmapping/proxy/ProxyMethodFilter.java
@@ -1,6 +1,8 @@
 package com.bivashy.configurate.objectmapping.proxy;
 
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Method;
+
 import org.spongepowered.configurate.serialize.SerializationException;
 
 /**
@@ -15,16 +17,18 @@ public interface ProxyMethodFilter {
      *
      * <p>For example, to ignore <b>synthetic</b> methods, one can use:</p>
      * <pre>
-     * ProxyMethodFilter filter = method -> !method.isSynthetic();
+     * ProxyMethodFilter filter = (method, type) ->
+     *      !method.isSynthetic();
      * </pre>
      *
      * <p>In the above example, the filter will exclude synthetic methods from further processing.</p>
      *
      * @param method The method from the interface to evaluate.
+     * @param type The annotated type use of the method to evaluate.
      * @return {@code true} if the method should be processed further, {@code false} if it should be ignored.
      * @throws SerializationException If the method has invalid syntax or cannot be evaluated.
      */
-    boolean test(Method method) throws SerializationException;
+    boolean test(Method method, AnnotatedType type) throws SerializationException;
 
     /**
      * Returns a new {@code ProxyMethodFilter} that negates the result of this filter.
@@ -34,6 +38,6 @@ public interface ProxyMethodFilter {
      * @return A new filter that negates the result of this filter.
      */
     default ProxyMethodFilter reverse() {
-        return (method) -> !this.test(method);
+        return (method, type) -> !this.test(method, type);
     }
 }

--- a/common/src/main/java/com/bivashy/configurate/objectmapping/common/meta/MethodInvokers.java
+++ b/common/src/main/java/com/bivashy/configurate/objectmapping/common/meta/MethodInvokers.java
@@ -18,6 +18,19 @@ public class MethodInvokers {
     private MethodInvokers() {
     }
 
+    public static ProxyMethodInvoker setterInvoker() {
+        return (proxy, method, args, intermediate) -> {
+            if (args == null || args.length != 1)
+                return null;
+            Class<?> returnType = method.getReturnType();
+            if (!returnType.equals(proxy.getClass()) && !returnType.equals(void.class))
+                return null;
+            Object argument = args[0];
+            intermediate.put(method.getName(), argument);
+            return proxy;
+        };
+    }
+
     public static ProxyMethodInvoker toStringInvoker() {
         return (proxy, method, args, intermediate) -> {
             if (methodNotEquals(method, "toString"))


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [X] Internal code
- [X] API (affecting end-user code)
- [ ] Other: _


Closes Issue: #3  

## Description

This pull request creates implementation for setters methods. 

**Breaking changes** Added `AnnotatedType type` parameter into `ProxyMethodFilter#test`

Currently no tests were created for this feature

Usage:
```java
public class Main {

    public static void main(String[] args) throws ConfigurateException {
        YamlConfigurationLoader loader = YamlConfigurationLoader.builder()
                .defaultOptions(
                        opt -> opt.serializers(builder -> builder.register(InterfaceObjectMapperFactory::applicable, new InterfaceObjectMapperFactory())))
                .source(() -> new BufferedReader(new InputStreamReader(ProximateConfigurateTest.class.getResourceAsStream("/input.yml"))))
                .sink(() -> new BufferedWriter(new FileWriter("output.yml")))
                .build();
                
        ConfigurationNode node = loader.load();
        User user = node.node("user").get(User.class);
        System.out.println(user.name());
        user.name("New name");
        System.out.println(user.name());
        node.node("user").set(User.class, user);
        loader.save(node);
    }

    @ConfigInterface
    public interface User {

        String name();

        void name(String newName);

    }

}
```
Output:
```
Hello
New name
```

**input.yml**:
```yml
user:
  name: 'Hello'
```

