### PR TITLE
[Fix] Transient and non-transient method collision

### DIFF
--- a/common/src/main/java/com/bivashy/configurate/objectmapping/common/InterfaceMethodDiscoverer.java
+++ b/common/src/main/java/com/bivashy/configurate/objectmapping/common/InterfaceMethodDiscoverer.java
@@ -53,6 +53,7 @@ final class InterfaceMethodDiscoverer implements FieldDiscoverer<Map<String, Obj
                                 "Interface methods should not have parameters: '" + method.toGenericString() + "'");
                     return true;
                 })
+                .invoker(MethodInvokers.transientDefaultInvoker())
                 .invoker(MethodInvokers.setterInvoker())
                 .invoker(MethodInvokers.toStringInvoker())
                 .invoker(MethodInvokers.equalsInvoker())

--- a/common/src/main/java/com/bivashy/configurate/objectmapping/common/ProxyInstanceFactory.java
+++ b/common/src/main/java/com/bivashy/configurate/objectmapping/common/ProxyInstanceFactory.java
@@ -34,11 +34,12 @@ class ProxyInstanceFactory implements InstanceFactory<Map<String, Object>> {
         return createProxy((proxy, method, args) -> {
             Object intermediateValue = intermediate.get(method.getName());
             Optional<Object> invocationResult = chooseInvocationResult(proxy, method, args, intermediate);
-            if (invocationResult.isPresent()) {
+
+            if (invocationResult.isPresent())
                 return invocationResult.get();
-            } else if (intermediateValue == null && method.isDefault()) {
+
+            if (intermediateValue == null && method.isDefault())
                 return ProxyDefaultMethodInvoker.invokeDefaultMethod(proxy, method, args);
-            }
 
             if (intermediateValue == null && method.getReturnType().isPrimitive())
                 return intermediate.computeIfAbsent(method.getName(), (ignored) -> Types.defaultValue(method.getReturnType()));

--- a/common/src/main/java/com/bivashy/configurate/objectmapping/common/meta/MethodInvokers.java
+++ b/common/src/main/java/com/bivashy/configurate/objectmapping/common/meta/MethodInvokers.java
@@ -11,11 +11,22 @@ import java.util.stream.Collectors;
 
 import com.bivashy.configurate.objectmapping.common.ProxyDefaultMethodInvoker;
 import com.bivashy.configurate.objectmapping.meta.Style;
+import com.bivashy.configurate.objectmapping.meta.Transient;
 import com.bivashy.configurate.objectmapping.proxy.ProxyMethodInvoker;
 
 public class MethodInvokers {
 
     private MethodInvokers() {
+    }
+
+    public static ProxyMethodInvoker transientDefaultInvoker() {
+        return (proxy, method, args, intermediate) -> {
+            if(!method.isDefault())
+                return null;
+            if (!method.isAnnotationPresent(Transient.class))
+                return null;
+            return ProxyDefaultMethodInvoker.invokeDefaultMethod(proxy, method, args);
+        };
     }
 
     public static ProxyMethodInvoker setterInvoker() {

--- a/common/src/test/java/com/bivashy/configurate/TransientMethodCollisionTest.java
+++ b/common/src/test/java/com/bivashy/configurate/TransientMethodCollisionTest.java
@@ -1,0 +1,52 @@
+package com.bivashy.configurate;
+
+import com.bivashy.configurate.objectmapping.ConfigInterface;
+import com.bivashy.configurate.objectmapping.common.InterfaceObjectMapperFactory;
+import com.bivashy.configurate.objectmapping.meta.Transient;
+import org.junit.jupiter.api.*;
+import org.spongepowered.configurate.CommentedConfigurationNode;
+import org.spongepowered.configurate.ConfigurateException;
+import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
+import org.spongepowered.configurate.serialize.TypeSerializerCollection;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TransientMethodCollisionTest {
+
+    @Test
+    void testMethodCollision() throws ConfigurateException {
+        InputStream resourceStream = getClass().getResourceAsStream("/basic-usage.conf");
+        assertNotNull(resourceStream);
+        final CommentedConfigurationNode node = HoconConfigurationLoader.builder()
+                .source(() -> new BufferedReader(new InputStreamReader(resourceStream)))
+                .defaultOptions(opt ->
+                        opt.serializers(builder -> builder
+                                .registerAll(TypeSerializerCollection.defaults())
+                                .register(InterfaceObjectMapperFactory::applicable, new InterfaceObjectMapperFactory())
+                        ))
+                .build()
+                .load();
+        ComplexConfiguration object = node.get(ComplexConfiguration.class);
+        assertNotNull(object);
+        assertNotNull(object.value());
+        assertEquals("test", object.value());
+        assertEquals(1, object.value(1));
+    }
+
+    @ConfigInterface
+    public interface ComplexConfiguration {
+
+        String value();
+
+        @Transient
+        default int value(int first) {
+            return first;
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [X] Internal code
- [ ] API (affecting end-user code)
- [X] Other: Test

Closes Issue
  - #8 

### Description
This pull request fixes conflict by simply creating `ProxyMethodInvoker` which executes if method is default, and has `@Transient` annotation.

### TODO
  - [x] Add test case that ensures bug doesn't happen again 
